### PR TITLE
John Muniz Implementation of the URL Shortener for Pocket Worlds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,9 @@ build:
 
 run: build
 	docker run -it --network pocket-network --rm -p 8000:8000/tcp --name url-shortener pw/url-shortener:latest
+
+redis:
+	docker run --name pocket-redis -d --network pocket-network redis redis-server --appendonly yes
+
+compose:
+	docker compose up

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ build:
 	docker build -t pw/url-shortener:latest .
 
 run: build
-	docker run -it --rm -p 8000:8000/tcp --name url-shortener pw/url-shortener:latest
+	docker run -it --network pocket-network --rm -p 8000:8000/tcp --name url-shortener pw/url-shortener:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  shortener-one:
+    build: .
+    ports:
+      - "8000:8000/tcp"
+  shortner-two:
+    build: .
+    ports:
+      - "8001:8000/tcp"
+  pocket-redis:
+    image: "redis"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.103.1
 pydantic==2.3.0
 uvicorn[standard]==0.23.2
+redis==5.0.1

--- a/server.py
+++ b/server.py
@@ -1,27 +1,48 @@
+import asyncio
 import random
 
 import redis.asyncio as redis
-from fastapi import FastAPI, HTTPException
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from urllib.parse import urlparse
 
-redis_client = redis.Redis(host="pocket-redis", port=6379, decode_responses=True)
-app = FastAPI()
-BASE_URL: str = "http://locahost:8000"
+
+@asynccontextmanager
+async def lifespan(application: FastAPI):
+    """
+    Lifecycle manager for handling the open Redis connection on startup and shutdown of the application
+    """
+    application.state.redis_client = redis.Redis(host="pocket-redis", port=6379, decode_responses=True)
+    yield
+    await application.state.redis_client.close()
+
+
+app = FastAPI(lifespan=lifespan)
+BASE_URL: str = "http://localhost:8000"
 BASE_SIZE: int = 8
 
 
-class ShortenRequest(BaseModel):
-    url: str
-
-
 def create_short_token(symbols: str = "0123456789abcdefghijklmnopqrstuvwxyz", size: int = BASE_SIZE) -> str:
+    """
+    Simple algorithm for creating a random short code.
+    """
     return ''.join(random.choice(symbols) for _ in range(size))
 
 
 def create_redis_token_key(token: str) -> str:
+    """
+    Helper method to decorate Redis key strings shorten token namespace.
+    """
     return "shorten_token:" + token
+
+
+def create_redis_rindex_key(target: str) -> str:
+    """
+    Helper method to decorate Redis key strings for reverse index.
+    """
+    return "rindex_key:" + target
 
 
 def is_valid_url(url: str) -> bool:
@@ -34,34 +55,52 @@ def is_valid_url(url: str) -> bool:
     return is_valid
 
 
+class ShortenRequest(BaseModel):
+    url: str
+
+
 @app.post("/url/shorten")
-async def url_shorten(request: ShortenRequest):
+async def url_shorten(shorten_request: ShortenRequest, request: Request):
     """
     Given a URL, generate a short version of the URL that can be later resolved to the originally
     specified URL.
     """
-    if not is_valid_url(request.url):
+    if not is_valid_url(shorten_request.url):
+        # Validate that input is a valid url format.
         raise HTTPException(status_code=400, detail="Invalid URL format.")
 
     max_token_attempts = 10
 
     short_size = BASE_SIZE
-    if len(request.url) < short_size:
-        short_size = len(request.url)
+    if len(shorten_request.url) < short_size:
+        # Simple test to keep the short code at least as short as the given url.
+        short_size = len(shorten_request.url)
 
     short_token = create_short_token(size=short_size)
     short_token_key = create_redis_token_key(short_token)
+    rindex_key = create_redis_rindex_key(shorten_request.url)
 
-    token_attempts = 0
-    while await redis_client.exists(short_token_key) and token_attempts < max_token_attempts:
-        short_token = create_short_token()
-        short_token_key = create_redis_token_key(short_token)
-        token_attempts += 1
+    existing_token = await request.app.state.redis_client.get(rindex_key)
+    if existing_token is not None:
+        # If we have shortened this URL before, return back the pre-existing token.
+        short_token = existing_token
     else:
-        if token_attempts < max_token_attempts:
-            await redis_client.set(short_token_key, request.url)
+        token_attempts = 0
+        while await request.app.state.redis_client.exists(short_token_key) and token_attempts < max_token_attempts:
+            # Try to generate an unused random code, up to a configurable threshold.
+            short_token = create_short_token()
+            short_token_key = create_redis_token_key(short_token)
+            token_attempts += 1
         else:
-            raise HTTPException(status_code=500, detail="Insufficient token space.")
+            if token_attempts < max_token_attempts:
+                # Add the token to the datastore, along with the reverse lookup to reduce redundancy.
+                await asyncio.gather(
+                    request.app.state.redis_client.set(short_token_key, shorten_request.url),
+                    request.app.state.redis_client.set(create_redis_rindex_key(shorten_request.url), short_token))
+
+            else:
+                # If we were unable to create a new random token, report back and error.
+                raise HTTPException(status_code=500, detail="Insufficient token space.")
 
     return {"short_url": f"{BASE_URL}/r/{short_token}"}
 
@@ -71,12 +110,12 @@ class ResolveRequest(BaseModel):
 
 
 @app.get("/r/{short_url}")
-async def url_resolve(short_url: str):
+async def url_resolve(short_url: str, request: Request):
     """
     Return a redirect response for a valid shortened URL string.
     If the short URL is unknown, return an HTTP 404 response.
     """
-    found_url = await redis_client.get(create_redis_token_key(short_url))
+    found_url = await request.app.state.redis_client.get(create_redis_token_key(short_url))
     if found_url is None:
         raise HTTPException(status_code=404, detail=f"Unknown short URL {found_url}")
 

--- a/server.py
+++ b/server.py
@@ -1,13 +1,37 @@
-from fastapi import FastAPI
+import random
+
+import redis.asyncio as redis
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
+from urllib.parse import urlparse
 
+redis_client = redis.Redis(host="pocket-redis", port=6379, decode_responses=True)
 app = FastAPI()
 BASE_URL: str = "http://locahost:8000"
+BASE_SIZE: int = 8
 
 
 class ShortenRequest(BaseModel):
     url: str
+
+
+def create_short_token(symbols: str = "0123456789abcdefghijklmnopqrstuvwxyz", size: int = BASE_SIZE) -> str:
+    return ''.join(random.choice(symbols) for _ in range(size))
+
+
+def create_redis_token_key(token: str) -> str:
+    return "shorten_token:" + token
+
+
+def is_valid_url(url: str) -> bool:
+    try:
+        result = urlparse(url)
+        is_valid = all((result.scheme, result.netloc))
+    except ValueError:
+        is_valid = False
+
+    return is_valid
 
 
 @app.post("/url/shorten")
@@ -16,8 +40,30 @@ async def url_shorten(request: ShortenRequest):
     Given a URL, generate a short version of the URL that can be later resolved to the originally
     specified URL.
     """
-    short_url = "new-short-url"
-    return {"short_url": f"{BASE_URL}/r/{short_url}"}
+    if not is_valid_url(request.url):
+        raise HTTPException(status_code=400, detail="Invalid URL format.")
+
+    max_token_attempts = 10
+
+    short_size = BASE_SIZE
+    if len(request.url) < short_size:
+        short_size = len(request.url)
+
+    short_token = create_short_token(size=short_size)
+    short_token_key = create_redis_token_key(short_token)
+
+    token_attempts = 0
+    while await redis_client.exists(short_token_key) and token_attempts < max_token_attempts:
+        short_token = create_short_token()
+        short_token_key = create_redis_token_key(short_token)
+        token_attempts += 1
+    else:
+        if token_attempts < max_token_attempts:
+            await redis_client.set(short_token_key, request.url)
+        else:
+            raise HTTPException(status_code=500, detail="Insufficient token space.")
+
+    return {"short_url": f"{BASE_URL}/r/{short_token}"}
 
 
 class ResolveRequest(BaseModel):
@@ -30,7 +76,11 @@ async def url_resolve(short_url: str):
     Return a redirect response for a valid shortened URL string.
     If the short URL is unknown, return an HTTP 404 response.
     """
-    return RedirectResponse("http://original/url")
+    found_url = await redis_client.get(create_redis_token_key(short_url))
+    if found_url is None:
+        raise HTTPException(status_code=404, detail=f"Unknown short URL {found_url}")
+
+    return RedirectResponse(url=found_url)
 
 
 @app.get("/")


### PR DESCRIPTION
## Getting Started - John Muniz Implementation

To begin the project, clone this repository to your local machine:

```commandline
git clone https://github.com/Johnny156/url-shortener-tech-test.git
```

This repository contains the implementation of a URL Shortener web service written in Python 3.11
using the [FastAPI](https://fastapi.tiangolo.com/) framework.

The API endpoints found in `server.py` have been implemented with proper business logic supported by a Redis datastore.

A Makefile, Dockerfile, and docker-compose.yml are also included for your convenience to run and test the web service.

While Docker is not required to run this service, this implementation utilized Docker to help manage multiple instances
and a running service of Redis from the [Redis Docker Official Image](https://www.docker.com/blog/how-to-use-the-redis-docker-official-image/).

### Prerequisites

The Redis Docker Official Image needs to be pulled in order to create the Redis container this can be achieved with a simple pull:
```commandline
docker pull redis
```

If you are not running the services with docker-compose a custom network will need to created so the service containers can communicate with the Redis container:

```commandline
docker create network pocket-network
```

This `pocket-network` should be referred to in any standalone containers run commands. 

### Running the service

#### docker-compose

Included in the project is a `docker-compose.yml` file that should encapsulate a running demo with two instances of the shortener container running on ports `8000` and `8001`, and the running Redis container:
```commandline
docker compose up
```
Included, is also a Makefile target which does the same thing:
```commandline
make compose
```

#### Makefile
I have modified the Makefile to include the custom network in the Docker run commands, and another target to spin up the Redis container:

```commandline
make redis
make run
```

This command will build a new Docker image (`pw/url-shortener:latest`) and start a container
instance in interactive mode.

The web service will run on port 8000, and the default Redis port is 6379.

### Testing

The Swagger UI was leveraged as a means of testing the endpoints, although any HTTP client (e.g. Postman, Browser/Dev tools) should suffice:
* `POST /url/shorten`
   *  Request Body, Content-Type: application/json, example request
   *  ```commandline
      {
        "url": "https://www.pocketworlds.com"
      }
      ```
* `GET /r/{short_url}`
   * The endpoint should return a 404, if the `short_url` is unknown
   * To test a known `short_url`, I recommend input the fully qualified short URL in the browser as this endpoint should return a redirect.

#### Expected Behaviors
* Known URLs shortened previous SHOULD return back the same shortened URL
* the `/url/shorten` endpoint SHOULD validate for proper URL formatting. (But not specifically http!)
* Reusing the included models and endpoint, the endpoints respond in JSON.

### Known Quirks
* While the Redis container is configured to have persistence, it will only have persistence across startup/shutdown of the SAME container. 
If the container is destroyed and remade, it will lose all its data. Proper mounting of Docker volumes would solve this issue, or moving to some sort of cloud Redis server (e.g. AWS Elasticache)
* The keys stored in Redis currently do not expire, this could be configured have tokens have a certain time-to-live and expire.
* The URL shortener tries to generate a (configurable) 8-character random unique token to shorten the URL up to 10 times, and will error out if the attempts are exceeded.

